### PR TITLE
Make this a template repo (instead of recommending that users fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a template repo for **training and publishing your own custom [DreamBoot
 
 ## Training the model
 
-1. 🍴 Fork this repository.
+1. 🐣 Create your own copy of this repository by clicking the green "Use this template" button, then "Create a new repository". Name your new repository whatever you like, and choose whether you want to make it public or private.
 1. 🐕 Remove the cute puppy images in the [data](data) directory and replace them with your own images.
 1. 💾 Commit your changes to git and push to your main branch on GitHub.
 1. 🕵️‍♀️ Copy your Replicate API token from [replicate.com/account](https://replicate.com/account) and [create a repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) named `REPLICATE_API_TOKEN`.


### PR DESCRIPTION
@bfirsh mentioned that we should probably make this a template repo instead of recommending that people fork it.

### Reason 1: Public vs Private

When you fork a public repo, your fork is public by default.

When you create a repo from a template, you're taken through a flow that lets you **choose whether the new repo should be public or private**. This is a better flow for this repo, because many users will want to train DreamBooth privately. It also aligns with the DreamBooth API behavior of defaulting to a private model.

### Reason 2: Fresh commit history

A new fork includes the entire commit history of the parent repository, while a repository created from a template starts with a single commit.

## To Do

- [x] Review and get approval on this PR
- [x] Flip the "Template repository" switch in https://github.com/replicate/dreambooth-action/settings
- [x] Ship this PR
